### PR TITLE
fix: public/private repo logic

### DIFF
--- a/commitlint_range.sh
+++ b/commitlint_range.sh
@@ -11,13 +11,13 @@ then
   echo "This is a pull request"
   PULL_REQUEST_NUMBER=$(echo "${CIRCLE_PULL_REQUEST}" | cut -d/ -f7)
   PULL_REQUEST_DETAILS=$(curl https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PULL_REQUEST_NUMBER})
-  REPO_IS_PRIVATE=$(echo "${PULL_REQUEST_DETAILS}" | jq -r .url)
-  if [ -n "${REPO_IS_PRIVATE}" ]
+  REPO_IS_PUBLIC=$(echo "${PULL_REQUEST_DETAILS}" | jq -r .url)
+  if [ -n "${REPO_IS_PUBLIC}" ]
   then
+    echo "Public repo"
+  else
     echo "Private repo"
     PULL_REQUEST_DETAILS=$(curl -H "Authorization: token ${GITHUB_TOKEN_COMMITLINT}" https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PULL_REQUEST_NUMBER})
-  else
-    echo "Public repo"
   fi
 
   BASE_SHA1=$(echo "${PULL_REQUEST_DETAILS}" | jq -r .base.sha)


### PR DESCRIPTION
#12 introduced backwards logic for determining public/private repos.

See: https://github.com/wilau2/circleci-commitlint-step/pull/12/commits/f43edb2263d044de41f53a42f9dbc45b0d115f6d#r432868788